### PR TITLE
FEAT: Add copy button for selected color (HEX and RGB)

### DIFF
--- a/src/components/ColorScale/ColorScale.test.tsx
+++ b/src/components/ColorScale/ColorScale.test.tsx
@@ -1,6 +1,14 @@
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
 import ColorScale from '.'
+
+const writeText = vi.fn()
+
+Object.assign(navigator, {
+  clipboard: {
+    writeText,
+  },
+});
 
 describe('ColorScale', () => {
   it('should render color picker', () => {
@@ -14,4 +22,23 @@ describe('ColorScale', () => {
 
     expect(screen.getByText('#FFEC70')).toBeDefined()
   })
+
+  it('should copy HEX and RGB initial color value', () => {
+    const hexAndRgbValues = ['#FFEC70', 'RGB(255, 236, 112)'];
+  
+    render(<ColorScale />);
+  
+    hexAndRgbValues.forEach((value) => {
+      expect(screen.getByText(value)).toBeDefined();
+    });
+  
+    const hexCopyButton = screen.getByLabelText('Copiar HEX da cor escolhida');
+    const rgbCopyButton = screen.getByLabelText('Copiar RGB da cor escolhida');
+  
+    fireEvent.click(hexCopyButton);
+    fireEvent.click(rgbCopyButton);
+  
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(hexAndRgbValues[0]);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(hexAndRgbValues[1]);
+  });
 })

--- a/src/components/ColorScale/index.tsx
+++ b/src/components/ColorScale/index.tsx
@@ -1,4 +1,4 @@
-import { Box, IconButton, Tooltip, Typography } from '@mui/material'
+import { Box, hexToRgb, IconButton, Tooltip, Typography } from '@mui/material'
 import { useState } from 'react'
 import { toast } from 'react-toastify'
 import { generateColorScale } from '../../utils/colorScale'
@@ -49,6 +49,21 @@ const ColorScale = () => {
     }
   }
 
+  const handleCopySelectedColor = async (color: string, colorType: string) => {
+    try {
+      await navigator.clipboard.writeText(color)
+      toast.success(`${colorType} da cor escolhida foi copiado!`, {
+        icon: () => '📋',
+        style: styles.toastMessage
+      })
+    } catch (err) {
+      toast.error(`Não foi possível copiar ${colorType} da cor escolhida`, {
+        icon: () => '❌',
+        style: styles.toastMessage
+      })
+    }
+  }
+
   const handleDownload = () => {
     const colorsText = colorScale.join('\n')
     const blob = new Blob([colorsText], { type: 'text/plain' })
@@ -70,17 +85,38 @@ const ColorScale = () => {
   return (
     <Box sx={styles.colorScaleContainer}>
       <Box sx={styles.colorPickerContainer}>
-        <Box sx={styles.colorPicker}>
-          <Typography sx={styles.colorPickerText}>Selecione sua cor</Typography>
-          <input
-            type="color"
-            value={selectedColor}
-            onChange={handleColorChange}
-            style={styles.colorPickerInput}
-          />
-          <Typography sx={styles.colorPickerSelectedColor}>
-            {selectedColor.toUpperCase()}
-          </Typography>
+        <Box sx={styles.colorPickerWrapper}>
+          <Box sx={styles.colorPicker}>
+            <Typography sx={styles.colorPickerText}>Selecione sua cor</Typography>
+            <input
+              type="color"
+              value={selectedColor}
+              onChange={handleColorChange}
+              style={styles.colorPickerInput}
+            />
+          </Box>
+
+          <Box sx={styles.colorPicker}>
+            <Typography sx={styles.colorPickerSelectedColor}>
+              {selectedColor.toUpperCase()}
+            </Typography>
+            <Tooltip title="Copiar HEX da cor escolhida" arrow placement="bottom">
+              <IconButton aria-label='Copiar HEX da cor escolhida' onClick={() => handleCopySelectedColor(selectedColor.toUpperCase(), 'HEX')} sx={styles.colorPickerAction}>
+                <ContentCopyIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </Box>
+
+          <Box sx={styles.colorPicker}>
+            <Typography sx={styles.colorPickerSelectedColor}>
+              {hexToRgb(selectedColor).toUpperCase()}
+            </Typography>
+            <Tooltip title="Copiar RGB da cor escolhida" arrow placement="bottom">
+              <IconButton aria-label='Copiar RGB da cor escolhida' onClick={() => handleCopySelectedColor(hexToRgb(selectedColor).toUpperCase(), 'RGB')} sx={styles.colorPickerAction}>
+                <ContentCopyIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </Box>
         </Box>
 
         <Box sx={styles.colorPickerActions}>

--- a/src/theme/styles.ts
+++ b/src/theme/styles.ts
@@ -123,11 +123,26 @@ export const styles = {
   },
   colorPickerContainer: {
     display: 'flex',
-    alignItems: 'center',
+    alignItems: {
+      xs: 'start',
+      md: 'center'
+    },
     justifyContent: 'space-between',
     backgroundColor: '#0e141d',
     px: 4,
     py: 2
+  },
+  colorPickerWrapper: {
+    display: 'flex',
+    gap: 2,
+    alignItems: {
+      xs: 'start',
+      md: 'center'
+    },
+    flexDirection: {
+      xs: 'column',
+      md: 'row'
+    }
   },
   colorPicker: {
     display: 'flex',


### PR DESCRIPTION
## Pull Request Title

Add copy button for selected color (HEX and RGB)

## Description

Add a button to copy HEX value of selected color and add next to HEX color the RGB color of Selected color. Also add tests for them and improve layout for mobile view.

## Related Issues

https://github.com/vitorbritto/coolorious/issues/2

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation (if necessary).

## Additional Notes

<!-- Include any other relevant information or context that reviewers should be aware of. -->
